### PR TITLE
Index på saksstatistikk sin funksjonellId

### DIFF
--- a/src/main/resources/db/migration/V07__indekser.sql
+++ b/src/main/resources/db/migration/V07__indekser.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS sak_funksjonellid_idx ON saksstatistikk_dvh(funksjonell_id);


### PR DESCRIPTION
Legger til indekser for å få lest unna flere meldinger per time. Grunnet ikke optimalisert consumer konfig og restartende errorhandler med sleep,  så er det et etterslep som vil ta en del dager slik det er nå.